### PR TITLE
Support large files on upload routine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -451,6 +451,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   "dependencies": {
     "airtable": "^0.8.1",
     "boxen": "^4.2.0",
+    "chalk": "^4.0.0",
     "csv-parser": "^2.3.3",
     "dotenv": "^8.2.0",
     "get-stream": "^5.1.0",
-    "chalk": "^4.0.0",
+    "lodash.chunk": "^4.2.0",
     "yargs": "^15.3.1"
   }
 }

--- a/src/csv/converters/obws.js
+++ b/src/csv/converters/obws.js
@@ -6,7 +6,7 @@ const AirtableMapping = {
     businessName: 'Business Name',
     category: 'Category',
     zipCode: 'Zip Code',
-    businessDescription: 'Description',
+    businessDescription: 'Business Description',
     website: 'Website',
     image: 'Image',
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,33 +2,48 @@ const chalk = require('chalk');
 const boxen = require("boxen");
 
 const boxenOptions = {
-  success: {
-    padding: 0,
-    margin: 0,
+  defaults: {
+    padding: 2,
+    margin: 1,
     borderStyle: "round",
+  },
+  success: {
     borderColor: "green",
-    backgroundColor: "#555555"
   },
   info: {
-    padding: 0,
-    margin: 0,
-    borderStyle: "round",
     borderColor: "blue",
-    backgroundColor: "#555555"
   },
   warning: {
-    padding: 0,
-    margin: 0,
-    borderStyle: "round",
     borderColor: "yellow",
-    backgroundColor: "#555555"
   }
 };
 
-function fancyLog(msg, type='info') {
+const chalkOptions = {
+  success: {
+    color: "green",
+  },
+  info: {
+    color: "blue",
+  },
+  warning: {
+    color: "yellow",
+  },
+  error: {
+    color: "red",
+  }
+}
+
+function fancyLog(msg, type='info', withBorder=false) {
   const fancyMessage = chalk.white.bold(msg);
-  const msgBox = boxen( fancyMessage, boxenOptions[type] );
-  console.log(msgBox);
+  if (withBorder) {
+    const finalBoxenOptions = Object.assign({}, boxenOptions.defaults, boxenOptions[type])
+    const msgBox = boxen( fancyMessage, finalBoxenOptions);
+    console.log(msgBox);
+  } else {
+    const chalkColor = chalkOptions[type].color
+    const fancyType = chalk[chalkColor](type.toUpperCase())
+    console.log(fancyType, fancyMessage, new Date().toISOString())
+  }
 }
 
 module.exports.fancyLog = fancyLog


### PR DESCRIPTION
When I attempted to upload the full OBWS CSV file I was met with an error informing me that the request body was too large.  I added chunking (max 10, per the API) to the upload routine and now it's humming along.

I also reworked the console messaging a bit since all the new messages coupled with the previous (larger) presentation was hard on the eyes.

Lastly, I fixed up a name change issue with `Storefront` and defaulted the `Category` to `Entertainment` for now so that anyone can run this without error.

